### PR TITLE
Fix tests by updating module path to `deeplabcut.benchmark`

### DIFF
--- a/scripts/encrypt_groundtruth.py
+++ b/scripts/encrypt_groundtruth.py
@@ -7,7 +7,7 @@ import itertools
 
 from cryptography.fernet import Fernet
 
-import benchmark._crypt
+import deeplabcut.benchmark._crypt
 
 def key_type(arg):
     if os.path.exists(arg) and os.path.isfile(arg):
@@ -34,7 +34,7 @@ if __name__ == "__main__":
         )
     )
     for file in files:
-        benchmark._crypt.encrypt(file, args.key)
+        deeplabcut.benchmark._crypt.encrypt(file, args.key)
     if args.store is None:
         print(
             f"Encrypted using key: {args.key.decode()}\n"

--- a/tests/_dlc_reference.py
+++ b/tests/_dlc_reference.py
@@ -16,7 +16,7 @@ from deeplabcut.pose_estimation_tensorflow.lib import inferenceutils
 from deeplabcut.pose_estimation_tensorflow.core import evaluate_multianimal
 from deeplabcut.utils.conversioncode import guarantee_multiindex_rows
 
-import benchmark.utils
+import deeplabcut.benchmark.utils
 
 MULTI_KEYPOINTS = {
     "trimouse": (

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,19 +1,19 @@
-import benchmark
-import benchmark.base
+import deeplabcut.benchmark
+import deeplabcut.benchmark.base
 
 def test_result():
-    result = benchmark.base.Result("foo", "bar")
+    result = deeplabcut.benchmark.base.Result("foo", "bar")
     restored = result.fromdict(result.todict())
     assert restored == result
-    assert result.benchmark_version == benchmark.__version__
+    assert result.benchmark_version == deeplabcut.__version__
 
 def test_collection():
 
-    collection = benchmark.base.ResultCollection()
+    collection = deeplabcut.benchmark.base.ResultCollection()
 
-    result1 = benchmark.base.Result("foo", "bar", root_mean_squared_error=42)
-    result2 = benchmark.base.Result("foo", "baz")
-    result_dup = benchmark.base.Result("foo", "bar", root_mean_squared_error=43)
+    result1 = deeplabcut.benchmark.base.Result("foo", "bar", root_mean_squared_error=42)
+    result2 = deeplabcut.benchmark.base.Result("foo", "baz")
+    result_dup = deeplabcut.benchmark.base.Result("foo", "bar", root_mean_squared_error=43)
 
     assert len(collection) == 0
     collection.add(result1)


### PR DESCRIPTION
Update `benchmark` -> `deeplabcut.benchmark` in the tests to make the instruction in the README runnable again. Change is necessary because we moved the core functionality to `deeplabcut.benchmark` prior to benchmark release.